### PR TITLE
Update README base on the v0.1-test.2 tag

### DIFF
--- a/README.md
+++ b/README.md
@@ -26,7 +26,7 @@ The following features have been implemented:
  - Record `perf` data of the whole system, TiDB modules, or specific process. (disabled by default)
  - Check the file size of TiDB modules' data directories. (enabled by default)
  - Collect and save log files of TiDB modules or system. (disabled by default)
- - Collect ans save various configuration files of system. (disabled by default)
+ - Collect and save various configuration files of system. (disabled by default)
  - Query PD API to collect runtime information of the TiDB cluster. (enabled by default)
 
 ### Usage
@@ -44,13 +44,13 @@ TiDB Insight Scripts
 optional arguments:
   -h, --help            show this help message and exit
   -o OUTPUT, --output OUTPUT
-                        The directory to store output data of TiDB Insight,
-                        any existing file will be overwritten without futher
+                        The directory to store output data of TiDB Insight.
+                        Any existing file will be overwritten without futher
                         confirmation.
   -p, --perf            Collect trace info using perf. Disabled by default.
-  --pid PID             PID of process to run perf on, if `-p/--perf` is not
+  --pid PID             PID of process to run perf on. If `-p`/`--perf` is not
                         set, this value will not take effect. Multiple PIDs
-                        can be set by using more than one --pid argument.
+                        can be set by using more than one `--pid` argument.
                         `None` by default which means the whole system.
   --tidb-proc           Collect perf data for PD/TiDB/TiKV processes instead
                         of the whole system.
@@ -70,12 +70,12 @@ optional arguments:
   --pd-host PD_HOST     The host of the PD server. `localhost` by default.
   --pd-port PD_PORT     The port of PD API service, `2379` by default.
 
-Note that some arguments would decrease system performance.
+Note that some arguments may decrease system performance.
 ```
 
 If `insight.py` is called with no argument provided, the following information is collected and saved to `data` directory in the current working directory:
 
- - `collector`, which provids the system information, program versions, NTP status, partition statistics and process statistics of TiDB modules (if present), placed in the `collector` sub-directory.
+ - `collector`, which provides the system information, program versions, NTP status, partition statistics and process statistics of TiDB modules (if present), placed in the `collector` sub-directory.
  - PD API output of `config`, `diagnose`, `health`, `hotspot`, `labels`, `members`, `operators`, `regions`, `regionstats`, `schedulers` and `status`, placed in the `pdctl` sub-directory in JSON format.
 
 Using `-o` can set another location to store output data except the default `data`.

--- a/README.md
+++ b/README.md
@@ -75,19 +75,21 @@ If calling `insight.py` with no argument provided, following information are col
  - `collector`, providing system information, program versions, NTP status, partition statics and process statics of TiDB modules (if present), placed under `collector` sub-directory.
  - PD API output of `config`, `diagnose`, `health`, `hotspot`, `labels`, `members`, `operators`, `regions`, `regionstats`, `schedulers` and `status`, placed under `pdctl` sub-directory in JSON format.
 
+Using `-o` can set another location to store output data other than the default `data`.
+
 ### Examples
 
 A common combination of params that could be useful is: `insight.py -l --config-file`, with which the basic system information, TiDB modules' log files and several config files are collected.
 
 If you want to collect runtime information of a TiDB cluster from PD on a remote host (instead of running the scripts on that server), set `--pd-host` to the IP address or a resolvable hostname of that host. Additionally, if PD is listening on non-default port, use `--pd-port` to set it.
 
-System log is not collectd by default, even if `-l` is set. If it's needed, use `-l --syslog` to enable it. Both `syslog` and `systemd-journald` log are supported, note that there is no content filter available for log files, thus enabling log file collection may leads to very large output size.
+System log is not collectd by default, even if `-l` is set. If needed, use `-l --syslog` to enable it. Both `syslog` and `systemd-journald` log are supported and automatically detected, note that there is no content filter available for log files, thus enabling log file collecting may leads to very large output size.
 
 ## Intergration with Ansible
 
 The tidb-insight project is designed to intergrate with [tidb-ansible](https://github.com/pingcap/tidb-ansible) playbooks.
 
-TO DO: Documents / Links to Documents of using tidb-insight with tidb-ansible.
+TO DO: Add documents / links to documents of using tidb-insight with tidb-ansible.
 
 ## Insight
 

--- a/README.md
+++ b/README.md
@@ -33,44 +33,46 @@ The following features have been implemented:
 
 For a full list of arguments, you may refer to the output of `insight.py -h`:
 
-    usage: insight.py [-h] [-o OUTPUT] [-p] [--pid PID] [--tidb-proc]
-                    [--perf-exec PERF_EXEC] [--perf-freq PERF_FREQ]
-                    [--perf-time PERF_TIME] [-l] [--syslog] [--config-file]
-                    [--pd-host PD_HOST] [--pd-port PD_PORT]
+```
+usage: insight.py [-h] [-o OUTPUT] [-p] [--pid PID] [--tidb-proc]
+                  [--perf-exec PERF_EXEC] [--perf-freq PERF_FREQ]
+                  [--perf-time PERF_TIME] [-l] [--syslog] [--config-file]
+                  [--pd-host PD_HOST] [--pd-port PD_PORT]
 
-    TiDB Insight Scripts
+TiDB Insight Scripts
 
-    optional arguments:
-    -h, --help            show this help message and exit
-    -o OUTPUT, --output OUTPUT
-                            The dir to store output data of TiDB Insight, any
-                            existing file will be overwritten without futher
-                            confirmation.
-    -p, --perf            Collect trace info with perf. Default is disabled.
-    --pid PID             PID of process to run perf on, if '-p/--perf' is not
-                            set, this value will be ignored and would not take any
-                            effection. Multiple PIDs can be set by using more than
-                            one --pid args. Default is None and means the whole
-                            system.
-    --tidb-proc           Collect perf data for PD/TiDB/TiKV processes instead
-                            of the whole system.
-    --perf-exec PERF_EXEC
-                            Custom path of perf executable file.
-    --perf-freq PERF_FREQ
-                            Event sampling frequency of perf-record, in Hz.
-    --perf-time PERF_TIME
-                            Time period of perf recording, in seconds.
-    -l, --log             Enable to include log files in output, PD/TiDB/TiKV
-                            logs are included by default.
-    --syslog              Enable to include system log in output, will be
-                            ignored if -l/--log is not set. This may significantly
-                            increase output size.
-    --config-file         Enable to include various config files in output,
-                            disabled by default.
-    --pd-host PD_HOST     The host of PD server. Default to localhost.
-    --pd-port PD_PORT     The port of PD API service, default to 2379.
+optional arguments:
+  -h, --help            show this help message and exit
+  -o OUTPUT, --output OUTPUT
+                        The dir to store output data of TiDB Insight, any
+                        existing file will be overwritten without futher
+                        confirmation.
+  -p, --perf            Collect trace info with perf. Default is disabled.
+  --pid PID             PID of process to run perf on, if '-p/--perf' is not
+                        set, this value will be ignored and would not take any
+                        effection. Multiple PIDs can be set by using more than
+                        one --pid args. Default is None and means the whole
+                        system.
+  --tidb-proc           Collect perf data for PD/TiDB/TiKV processes instead
+                        of the whole system.
+  --perf-exec PERF_EXEC
+                        Custom path of perf executable file.
+  --perf-freq PERF_FREQ
+                        Event sampling frequency of perf-record, in Hz.
+  --perf-time PERF_TIME
+                        Time period of perf recording, in seconds.
+  -l, --log             Enable to include log files in output, PD/TiDB/TiKV
+                        logs are included by default.
+  --syslog              Enable to include system log in output, will be
+                        ignored if -l/--log is not set. This may significantly
+                        increase output size.
+  --config-file         Enable to include various config files in output,
+                        disabled by default.
+  --pd-host PD_HOST     The host of PD server. Default to localhost.
+  --pd-port PD_PORT     The port of PD API service, default to 2379.
 
-    Note that some arguments would decrease system performance.
+Note that some arguments would decrease system performance.
+```
 
 If calling `insight.py` with no argument provided, following information are collected and saved to `data` directory of current working directory:
 

--- a/README.md
+++ b/README.md
@@ -26,8 +26,8 @@ The following features have been implemented:
  - Record `perf` data of the whole system, TiDB modules, or specific process. (disabled by default)
  - Check the file size of TiDB modules' data directories. (enabled by default)
  - Collect and save log files of TiDB modules or system. (disabled by default)
- - Collect ans save various config files of system. (disabled by default)
- - Query PD API to collect runtime information of TiDB cluster. (enabled by default)
+ - Collect ans save various configuration files of system. (disabled by default)
+ - Query PD API to collect runtime information of the TiDB cluster. (enabled by default)
 
 ### Usage
 
@@ -44,15 +44,14 @@ TiDB Insight Scripts
 optional arguments:
   -h, --help            show this help message and exit
   -o OUTPUT, --output OUTPUT
-                        The dir to store output data of TiDB Insight, any
-                        existing file will be overwritten without futher
+                        The directory to store output data of TiDB Insight,
+                        any existing file will be overwritten without futher
                         confirmation.
-  -p, --perf            Collect trace info with perf. Default is disabled.
-  --pid PID             PID of process to run perf on, if '-p/--perf' is not
-                        set, this value will be ignored and would not take any
-                        effection. Multiple PIDs can be set by using more than
-                        one --pid args. Default is None and means the whole
-                        system.
+  -p, --perf            Collect trace info using perf. Disabled by default.
+  --pid PID             PID of process to run perf on, if `-p/--perf` is not
+                        set, this value will not take effect. Multiple PIDs
+                        can be set by using more than one --pid argument.
+                        `None` by default which means the whole system.
   --tidb-proc           Collect perf data for PD/TiDB/TiKV processes instead
                         of the whole system.
   --perf-exec PERF_EXEC
@@ -61,41 +60,41 @@ optional arguments:
                         Event sampling frequency of perf-record, in Hz.
   --perf-time PERF_TIME
                         Time period of perf recording, in seconds.
-  -l, --log             Enable to include log files in output, PD/TiDB/TiKV
-                        logs are included by default.
-  --syslog              Enable to include system log in output, will be
-                        ignored if -l/--log is not set. This may significantly
-                        increase output size.
-  --config-file         Enable to include various config files in output,
+  -l, --log             Collect log files in output. PD/TiDB/TiKV logs are
+                        included by default.
+  --syslog              Collect the system log in output. This may
+                        significantly increase output size. If `-l/--log` is
+                        not set, the system log will be ignored.
+  --config-file         Collect various configuration files in output,
                         disabled by default.
-  --pd-host PD_HOST     The host of PD server. Default to localhost.
-  --pd-port PD_PORT     The port of PD API service, default to 2379.
+  --pd-host PD_HOST     The host of the PD server. `localhost` by default.
+  --pd-port PD_PORT     The port of PD API service, `2379` by default.
 
 Note that some arguments would decrease system performance.
 ```
 
-If calling `insight.py` with no argument provided, following information are collected and saved to `data` directory of current working directory:
+If `insight.py` is called with no argument provided, the following information is collected and saved to `data` directory in the current working directory:
 
- - `collector`, providing system information, program versions, NTP status, partition statics and process statics of TiDB modules (if present), placed under `collector` sub-directory.
- - PD API output of `config`, `diagnose`, `health`, `hotspot`, `labels`, `members`, `operators`, `regions`, `regionstats`, `schedulers` and `status`, placed under `pdctl` sub-directory in JSON format.
+ - `collector`, which provids the system information, program versions, NTP status, partition statistics and process statistics of TiDB modules (if present), placed in the `collector` sub-directory.
+ - PD API output of `config`, `diagnose`, `health`, `hotspot`, `labels`, `members`, `operators`, `regions`, `regionstats`, `schedulers` and `status`, placed in the `pdctl` sub-directory in JSON format.
 
-Using `-o` can set another location to store output data other than the default `data`.
+Using `-o` can set another location to store output data except the default `data`.
 
 ### Examples
 
-A common combination of params that could be useful is: `insight.py -l --config-file`, with which the basic system information, TiDB modules' log files and several config files are collected.
+Take `insight.py -l --config-file`, a common combination of arguments as an example. It is used to collect the basic system information, TiDB modules' log files and several config files.
 
 If you want to collect runtime information of a TiDB cluster from PD on a remote host (instead of running the scripts on that server), set `--pd-host` to the IP address or a resolvable hostname of that host. Additionally, if PD is listening on non-default port, use `--pd-port` to set it.
 
-System log is not collectd by default, even if `-l` is set. If needed, use `-l --syslog` to enable it. Both `syslog` and `systemd-journald` log are supported and automatically detected, note that there is no content filter available for log files, thus enabling log file collecting may leads to very large output size.
+The system log is not collectd by default, even if `-l` is set. If needed, use `-l --syslog` to enable it. Both `syslog` and `systemd-journald` logs are supported and automatically detected. Note that there is no content filter available for log files, thus enabling log file collecting may lead to a very large output size.
 
 ## Intergration with Ansible
 
-The tidb-insight project is designed to intergrate with [tidb-ansible](https://github.com/pingcap/tidb-ansible) playbooks.
+The `tidb-insight` project is designed to intergrate with [tidb-ansible](https://github.com/pingcap/tidb-ansible) playbooks.
 
-> All collecting features will be disabled by default after the development of intergration is finished, so it's highly recommended to specify all the args needed when using tidb-insight now, even if the feature is currently enabled by default.
+> All collecting features will be disabled by default after the development of intergration is finished, so it's highly recommended to specify all the arguments needed when using `tidb-insight` now, even if the feature is currently enabled by default.
 
-TO DO: Add documents / links to documents of using tidb-insight with tidb-ansible.
+TO DO: Add documents/links to documents of using `tidb-insight` with `tidb-ansible`.
 
 ## Insight
 

--- a/README.md
+++ b/README.md
@@ -3,15 +3,15 @@
 [![Build Status](https://travis-ci.org/pingcap/tidb-insight.svg?branch=master)](https://travis-ci.org/pingcap/tidb-insight)
 [![Go Report Card](https://goreportcard.com/badge/github.com/pingcap/tidb-insight)](https://goreportcard.com/report/github.com/pingcap/tidb-insight)
 
-This is a set of tools and/or scripts to collect information and metrics from all nodes of a TiDB cluster. The data is collected and archived to a tarball so that one can copy the data to anywhere convenient for further investigation.
+TiDB Insight is a set of tools and/or scripts to collect information and metrics from all nodes of a TiDB cluster. The data is collected and archived to a tarball so that one can copy the data anywhere for further investigation.
 
-You may find it useful when you don't have access to the machines running TiDB services, but need to troubleshooting issues related to them.
+TiDB Insight is designed to help you troubleshoot and diagnose machines within a TiDB cluster when you don't have access to the cluster.
 
 ## Collector
 
 The `collector` is a simple binary tool written in Go that collects various kinds of server information, including system information, TiDB/TiKV/PD versions, etc.
 
-The output of `collector` is a JSON to stdout.
+`collector` prints a JSON to stdout.
 
 ## Scripts
 

--- a/README.md
+++ b/README.md
@@ -89,6 +89,8 @@ System log is not collectd by default, even if `-l` is set. If needed, use `-l -
 
 The tidb-insight project is designed to intergrate with [tidb-ansible](https://github.com/pingcap/tidb-ansible) playbooks.
 
+> All collecting features will be disabled by default after the development of intergration is finished, so it's highly recommended to specify all the args needed when using tidb-insight now, even if the feature is currently enabled by default.
+
 TO DO: Add documents / links to documents of using tidb-insight with tidb-ansible.
 
 ## Insight

--- a/README.md
+++ b/README.md
@@ -9,7 +9,7 @@ You may find it useful when you don't have access to the machines running TiDB s
 
 ## Collector
 
-The `collector` is a simple binary tool that collects various kinds of server information, including system information, TiDB/TiKV/PD versions, etc.
+The `collector` is a simple binary tool written in Go that collects various kinds of server information, including system information, TiDB/TiKV/PD versions, etc.
 
 The output of `collector` is a JSON to stdout.
 
@@ -25,6 +25,55 @@ The following features have been implemented:
 
  - Record `perf` data of the whole system, TiDB modules, or specific process. (disabled by default)
  - Check the file size of TiDB modules' data directories. (enabled by default)
+ - Collect and save log files of TiDB modules or system. (disabled by default)
+ - Collect ans save various config files of system. (disabled by default)
+ - Query PD API to collect runtime information of TiDB cluster. (enabled by default)
+
+### Usage
+
+    usage: insight.py [-h] [-o OUTPUT] [-p] [--pid PID] [--tidb-proc]
+                    [--perf-exec PERF_EXEC] [--perf-freq PERF_FREQ]
+                    [--perf-time PERF_TIME] [-l] [--syslog] [--config-file]
+                    [--pd-host PD_HOST] [--pd-port PD_PORT]
+
+    TiDB Insight Scripts
+
+    optional arguments:
+    -h, --help            show this help message and exit
+    -o OUTPUT, --output OUTPUT
+                            The dir to store output data of TiDB Insight, any
+                            existing file will be overwritten without futher
+                            confirmation.
+    -p, --perf            Collect trace info with perf. Default is disabled.
+    --pid PID             PID of process to run perf on, if '-p/--perf' is not
+                            set, this value will be ignored and would not take any
+                            effection. Multiple PIDs can be set by using more than
+                            one --pid args. Default is None and means the whole
+                            system.
+    --tidb-proc           Collect perf data for PD/TiDB/TiKV processes instead
+                            of the whole system.
+    --perf-exec PERF_EXEC
+                            Custom path of perf executable file.
+    --perf-freq PERF_FREQ
+                            Event sampling frequency of perf-record, in Hz.
+    --perf-time PERF_TIME
+                            Time period of perf recording, in seconds.
+    -l, --log             Enable to include log files in output, PD/TiDB/TiKV
+                            logs are included by default.
+    --syslog              Enable to include system log in output, will be
+                            ignored if -l/--log is not set. This may significantly
+                            increase output size.
+    --config-file         Enable to include various config files in output,
+                            disabled by default.
+    --pd-host PD_HOST     The host of PD server. Default to localhost.
+    --pd-port PD_PORT     The port of PD API service, default to 2379.
+
+    Note that some options would decrease system performance.
+
+If calling `insight.py` with no argument provided, following information are collected and saved to `data` directory of current working directory:
+
+ - `collector`, providing system information, program versions, NTP status, partition statics and process statics of TiDB modules (if present), placed under `collector` sub-directory.
+ - PD API output of `config`, `diagnose`, `health`, `hotspot`, `labels`, `members`, `operators`, `regions`, `regionstats`, `schedulers` and `status`, placed under `pdctl` sub-directory in JSON format.
 
 ## Insight
 

--- a/README.md
+++ b/README.md
@@ -75,6 +75,20 @@ If calling `insight.py` with no argument provided, following information are col
  - `collector`, providing system information, program versions, NTP status, partition statics and process statics of TiDB modules (if present), placed under `collector` sub-directory.
  - PD API output of `config`, `diagnose`, `health`, `hotspot`, `labels`, `members`, `operators`, `regions`, `regionstats`, `schedulers` and `status`, placed under `pdctl` sub-directory in JSON format.
 
+### Examples
+
+A common combination of params that could be useful is: `insight.py -l --config-file`, with which the basic system information, TiDB modules' log files and several config files are collected.
+
+If you want to collect runtime information of a TiDB cluster from PD on a remote host (instead of running the scripts on that server), set `--pd-host` to the IP address or a resolvable hostname of that host. Additionally, if PD is listening on non-default port, use `--pd-port` to set it.
+
+System log is not collectd by default, even if `-l` is set. If it's needed, use `-l --syslog` to enable it. Both `syslog` and `systemd-journald` log are supported, note that there is no content filter available for log files, thus enabling log file collection may leads to very large output size.
+
+## Intergration with Ansible
+
+The tidb-insight project is designed to intergrate with [tidb-ansible](https://github.com/pingcap/tidb-ansible) playbooks.
+
+TO DO: Documents / Links to Documents of using tidb-insight with tidb-ansible.
+
 ## Insight
 
 TO DO: Create the analysis tool that helps process dataset.

--- a/README.md
+++ b/README.md
@@ -31,6 +31,8 @@ The following features have been implemented:
 
 ### Usage
 
+For a full list of arguments, you may refer to the output of `insight.py -h`:
+
     usage: insight.py [-h] [-o OUTPUT] [-p] [--pid PID] [--tidb-proc]
                     [--perf-exec PERF_EXEC] [--perf-freq PERF_FREQ]
                     [--perf-time PERF_TIME] [-l] [--syslog] [--config-file]
@@ -68,7 +70,7 @@ The following features have been implemented:
     --pd-host PD_HOST     The host of PD server. Default to localhost.
     --pd-port PD_PORT     The port of PD API service, default to 2379.
 
-    Note that some options would decrease system performance.
+    Note that some arguments would decrease system performance.
 
 If calling `insight.py` with no argument provided, following information are collected and saved to `data` directory of current working directory:
 

--- a/measurement/util.py
+++ b/measurement/util.py
@@ -56,11 +56,11 @@ def parse_insight_opts():
     parser = argparse.ArgumentParser(description="TiDB Insight Scripts",
                                      epilog="Note that some arguments may decrease system performance.")
     parser.add_argument("-o", "--output", action="store", default=None,
-                        help="""The directory to store output data of TiDB Insight, any existing file will be overwritten without futher confirmation.""")
+                        help="""The directory to store output data of TiDB Insight. Any existing file will be overwritten without futher confirmation.""")
     parser.add_argument("-p", "--perf", action="store_true", default=False,
                         help="Collect trace info using perf. Disabled by default.")
     parser.add_argument("--pid", type=int, action="append", default=None,
-                        help="""PID of process to run perf on, if `-p/--perf` is not set, this value will not take effect. Multiple PIDs can be set by using more than one --pid argument. `None` by default which means the whole system.""")
+                        help="""PID of process to run perf on. If `-p`/`--perf` is not set, this value will not take effect. Multiple PIDs can be set by using more than one `--pid` argument. `None` by default which means the whole system.""")
     parser.add_argument("--tidb-proc", action="store_true", default=False,
                         help="Collect perf data for PD/TiDB/TiKV processes instead of the whole system.")
     parser.add_argument("--perf-exec", type=int, action="store", default=None,

--- a/measurement/util.py
+++ b/measurement/util.py
@@ -54,18 +54,13 @@ def parse_cmdline(cmdline):
 
 def parse_insight_opts():
     parser = argparse.ArgumentParser(description="TiDB Insight Scripts",
-                                     epilog="Note that some arguments would decrease system performance.")
+                                     epilog="Note that some arguments may decrease system performance.")
     parser.add_argument("-o", "--output", action="store", default=None,
-                        help="""The dir to store output data of TiDB Insight, any existing file
-                        will be overwritten without futher confirmation.""")
-
+                        help="""The directory to store output data of TiDB Insight, any existing file will be overwritten without futher confirmation.""")
     parser.add_argument("-p", "--perf", action="store_true", default=False,
-                        help="Collect trace info with perf. Default is disabled.")
+                        help="Collect trace info using perf. Disabled by default.")
     parser.add_argument("--pid", type=int, action="append", default=None,
-                        help="""PID of process to run perf on, if '-p/--perf' is not set, this
-                        value will be ignored and would not take any effection.
-                        Multiple PIDs can be set by using more than one --pid args.
-                        Default is None and means the whole system.""")
+                        help="""PID of process to run perf on, if `-p/--perf` is not set, this value will not take effect. Multiple PIDs can be set by using more than one --pid argument. `None` by default which means the whole system.""")
     parser.add_argument("--tidb-proc", action="store_true", default=False,
                         help="Collect perf data for PD/TiDB/TiKV processes instead of the whole system.")
     parser.add_argument("--perf-exec", type=int, action="store", default=None,
@@ -75,15 +70,15 @@ def parse_insight_opts():
     parser.add_argument("--perf-time", type=int, action="store", default=None,
                         help="Time period of perf recording, in seconds.")
     parser.add_argument("-l", "--log", action="store_true", default=False,
-                        help="Enable to include log files in output, PD/TiDB/TiKV logs are included by default.")
+                        help="Collect log files in output. PD/TiDB/TiKV logs are included by default.")
     parser.add_argument("--syslog", action="store_true", default=False,
-                        help="Enable to include system log in output, will be ignored if -l/--log is not set. This may significantly increase output size.")
+                        help="Collect the system log in output. This may significantly increase output size. If `-l/--log` is not set, the system log will be ignored.")
     parser.add_argument("--config-file", action="store_true", default=False,
-                        help="Enable to include various config files in output, disabled by default.")
+                        help="Collect various configuration files in output, disabled by default.")
     parser.add_argument("--pd-host", action="store", default=None,
-                        help="The host of PD server. Default to localhost.")
+                        help="The host of the PD server. `localhost` by default.")
     parser.add_argument("--pd-port", type=int, action="store", default=None,
-                        help="The port of PD API service, default to 2379.")
+                        help="The port of PD API service, `2379` by default.")
 
     return parser.parse_args()
 

--- a/measurement/util.py
+++ b/measurement/util.py
@@ -54,7 +54,7 @@ def parse_cmdline(cmdline):
 
 def parse_insight_opts():
     parser = argparse.ArgumentParser(description="TiDB Insight Scripts",
-                                     epilog="Note that some options would decrease system performance.")
+                                     epilog="Note that some arguments would decrease system performance.")
     parser.add_argument("-o", "--output", action="store", default=None,
                         help="""The dir to store output data of TiDB Insight, any existing file
                         will be overwritten without futher confirmation.""")


### PR DESCRIPTION
Update readme file to follow up codebase of v0.1-test.2 tag.

 - Add usage & argument descriptions of `insight.py`
 - Add basic examples
 - Add note of under-development feature of intergration with ansible playbooks

@CaitinChen PTAL