### PR TITLE
Add ability to collect log files with ansible playbook

### DIFF
--- a/insight.py
+++ b/insight.py
@@ -36,16 +36,21 @@ class Insight():
     # data output dir
     outdir = "data"
     full_outdir = ""
+    alias = ""
 
     insight_perf = None
     insight_logfiles = None
     insight_configfiles = None
     insight_pdctl = None
 
-    def __init__(self, outdir=None):
-        if outdir:
-            self.outdir = outdir
-        self.full_outdir = fileutils.create_dir(self.outdir)
+    def __init__(self, args):
+        if args.output:
+            self.outdir = args.output
+        if not args.alias:
+            self.alias = util.get_hostname()
+        self.full_outdir = fileutils.create_dir(
+            os.path.join(self.outdir, self.alias))
+        logging.debug("Output directory is: %s" % self.full_outdir)
 
     # data collected by `collector`
     collector_data = {}
@@ -165,6 +170,8 @@ class Insight():
         if args.log_auto:
             self.insight_logfiles.save_logfiles_auto(
                 proc_cmdline=proc_cmdline, outputdir=self.outdir)
+        else:
+            self.insight_logfiles.save_tidb_logfiles(outputdir=self.outdir)
         self.insight_logfiles.save_system_log(outputdir=self.outdir)
 
     def save_configs(self, args):
@@ -197,8 +204,7 @@ if __name__ == "__main__":
         logging.basicConfig(level=logging.DEBUG)
         logging.debug("Debug logging enabled.")
 
-    insight = Insight(args.output)
-    logging.debug("Output directory is: %s" % insight.full_outdir)
+    insight = Insight(args)
 
     insight.collector()
     # WIP: call scripts that collect metrics of the node

--- a/insight.py
+++ b/insight.py
@@ -162,8 +162,10 @@ class Insight():
 
         self.insight_logfiles = logfiles.InsightLogFiles(options=args)
         proc_cmdline = self.format_proc_info("cmd")  # cmdline of process
-        self.insight_logfiles.save_logfiles(
-            proc_cmdline=proc_cmdline, outputdir=self.outdir)
+        if args.log_auto:
+            self.insight_logfiles.save_logfiles_auto(
+                proc_cmdline=proc_cmdline, outputdir=self.outdir)
+        self.insight_logfiles.save_system_log(outputdir=self.outdir)
 
     def save_configs(self, args):
         if not args.config_file:

--- a/measurement/files/fileutils.py
+++ b/measurement/files/fileutils.py
@@ -29,7 +29,7 @@ def write_file(filename, data):
 # create target directory, do nothing if it already exists
 def create_dir(path):
     try:
-        os.mkdir(path)
+        os.makedirs(path)
         return path
     except OSError as e:
         # There is FileExistsError (devided from OSError) in Python 3.3+,
@@ -56,3 +56,18 @@ def build_full_output_dir(basedir=None, subdir=None):
     else:
         # full path of basedir/subdir
         return create_dir(os.path.join(basedir, subdir))
+
+
+def compress_tarball(output_base=None, output_name=None):
+    # compress output files to tarball
+    os.chdir(output_base)
+    cmd = ["tar",
+           "--remove-files",
+           "-zcf",
+           "%s.tar.gz" % output_name,
+           output_name]
+    stdout, stderr = util.run_cmd(cmd)
+    if not stderr and stderr != '':
+        logging.info("tar stderr: %s" % stderr)
+    if not stdout and stdout != '':
+        logging.debug("tar output: %s" % stdout)

--- a/measurement/files/logfiles.py
+++ b/measurement/files/logfiles.py
@@ -70,7 +70,7 @@ class InsightLogFiles():
         for logfile in glob(syslog_path) + glob(dmesg_path):
             self.save_logfile_to_dir(logfile=logfile, outputdir=outputdir)
 
-    def save_logfiles(self, proc_cmdline=None, outputdir=None):
+    def save_logfiles_auto(self, proc_cmdline=None, outputdir=None):
         # save log files of TiDB modules
         for pid, cmdline in proc_cmdline.items():
             proc_logfile = self.find_tidb_logfiles(cmdline=cmdline)
@@ -78,6 +78,7 @@ class InsightLogFiles():
                                      savename="%s.log" % pid,
                                      outputdir=outputdir)
 
+    def save_system_log(self, outputdir=None):
         # save system logs
         if self.log_options.syslog:
             if util.get_init_type() == "systemd":

--- a/measurement/util.py
+++ b/measurement/util.py
@@ -73,6 +73,8 @@ def parse_insight_opts():
                         help="Collect log files in output. PD/TiDB/TiKV logs are included by default.")
     parser.add_argument("--syslog", action="store_true", default=False,
                         help="Collect the system log in output. This may significantly increase output size. If `-l/--log` is not set, the system log will be ignored.")
+    parser.add_argument("--log-auto", action="store_true", default=False,
+                        help="Automatically detect and save log files of running PD/TiDB/TiKV process.")
     parser.add_argument("--config-file", action="store_true", default=False,
                         help="Collect various configuration files in output, disabled by default.")
     parser.add_argument("--pd-host", action="store", default=None,

--- a/measurement/util.py
+++ b/measurement/util.py
@@ -57,6 +57,9 @@ def parse_insight_opts():
                                      epilog="Note that some arguments may decrease system performance.")
     parser.add_argument("-o", "--output", action="store", default=None,
                         help="""The directory to store output data of TiDB Insight. Any existing file will be overwritten without futher confirmation.""")
+    parser.add_argument("--alias", action="store", default=None,
+                        help="The alias of this instance. This value be part of the name of output tarball.")
+
     parser.add_argument("-p", "--perf", action="store_true", default=False,
                         help="Collect trace info using perf. Disabled by default.")
     parser.add_argument("--pid", type=int, action="append", default=None,
@@ -75,6 +78,13 @@ def parse_insight_opts():
                         help="Collect the system log in output. This may significantly increase output size. If `-l/--log` is not set, the system log will be ignored.")
     parser.add_argument("--log-auto", action="store_true", default=False,
                         help="Automatically detect and save log files of running PD/TiDB/TiKV process.")
+    parser.add_argument("--log-dir", action="store", default=None,
+                        help="Location of log files. If `--log-auto` is set, this value will be ignored.")
+    parser.add_argument("--log-prefix", action="store", default=None,
+                        help="The prefix of log files, will be the directory name of all logs, will be in the name of output tarball. If `--log-auto` is set, this value will be ignored.")
+    parser.add_argument("--log-retention", action="store", type=int, default=0,
+                        help="The time of log retention, any log files older than given time period from current time will not be included. Value should be a number of hour(s) in positive interger. `0` by default and means no time check.")
+
     parser.add_argument("--config-file", action="store_true", default=False,
                         help="Collect various configuration files in output, disabled by default.")
     parser.add_argument("--pd-host", action="store", default=None,

--- a/measurement/util.py
+++ b/measurement/util.py
@@ -108,3 +108,9 @@ def read_url(url, data=None):
     except URLError as e:
         logging.warning("Reading URL %s error: %s" % (url, e))
         return None
+
+
+def get_hostname():
+    # This function is merely used, so only import socket package when necessary
+    import socket
+    return socket.gethostname()


### PR DESCRIPTION
The `compress_tarball()` method is added but not used yet, it will be used to compress all output data (not only logfiles), this part of work will be in another PR.