### PR TITLE
logfiles: fix base dir & typo

### DIFF
--- a/measurement/files/logfiles.py
+++ b/measurement/files/logfiles.py
@@ -115,8 +115,8 @@ class InsightLogFiles():
         retention_hour = self.log_options.log_retention
 
         # prepare output directory
-        if not fileutils.create_dir(outputdir):
-            logging.fatal("Failed to preopare output dir")
+        if not fileutils.create_dir(output_base):
+            logging.fatal("Failed to prepare output dir")
             return
 
         # the output tarball name

--- a/measurement/util.py
+++ b/measurement/util.py
@@ -56,7 +56,7 @@ def parse_insight_opts():
     parser = argparse.ArgumentParser(description="TiDB Insight Scripts",
                                      epilog="Note that some arguments may decrease system performance.")
     parser.add_argument("-o", "--output", action="store", default=None,
-                        help="""The directory to store output data of TiDB Insight. Any existing file will be overwritten without futher confirmation.""")
+                        help="The directory to store output data of TiDB Insight. Any existing file will be overwritten without futher confirmation.")
     parser.add_argument("--alias", action="store", default=None,
                         help="The alias of this instance. This value be part of the name of output tarball.")
 


### PR DESCRIPTION
 - Use proper base dir when saving log files
 - Fix a typo in logging message