### PR TITLE
Add ability to collect perf data of process by specifying its listening port

### DIFF
--- a/insight.py
+++ b/insight.py
@@ -223,19 +223,24 @@ if __name__ == "__main__":
 
     insight = Insight(args)
 
-    insight.collector()
+    if (not args.pid and not args.proc_listen_port
+        and not args.log_auto and not args.config_auto
+        ):
+        insight.collector()
+        # check size of data folder of TiDB processes
+        insight.get_datadir_size()
+        # list files opened by TiDB processes
+        insight.get_lsof_tidb()
     # WIP: call scripts that collect metrics of the node
     insight.run_perf(args)
-    # check size of data folder of TiDB processes
-    insight.get_datadir_size()
-    # list files opened by TiDB processes
-    insight.get_lsof_tidb()
     # save log files
     insight.save_logfiles(args)
     # save config files
     insight.save_configs(args)
-    # read and save `pd-ctl` info
-    insight.read_pdctl(args)
+
+    if args.pdctl:
+        # read and save `pd-ctl` info
+        insight.read_pdctl(args)
 
     # compress all output to tarball
     if args.compress:

--- a/insight.py
+++ b/insight.py
@@ -116,7 +116,7 @@ class Insight():
         elif args.proc_listen_port:
             perf_proc = {}
             pid_list = proc_meta.find_process_by_port(
-                args.proc_listen_port, args.proc_port_proto)
+                args.proc_listen_port, args.proc_listen_proto)
             if not pid_list or len(pid_list) < 1:
                 return
             for _pid in pid_list:

--- a/insight.py
+++ b/insight.py
@@ -180,10 +180,11 @@ class Insight():
         proc_cmdline = self.format_proc_info("cmd")  # cmdline of process
         if args.log_auto:
             self.insight_logfiles.save_logfiles_auto(
-                proc_cmdline=proc_cmdline, outputdir=self.outdir)
+                proc_cmdline=proc_cmdline, outputdir=self.full_outdir)
         else:
-            self.insight_logfiles.save_tidb_logfiles(outputdir=self.outdir)
-        self.insight_logfiles.save_system_log(outputdir=self.outdir)
+            self.insight_logfiles.save_tidb_logfiles(
+                outputdir=self.full_outdir)
+        self.insight_logfiles.save_system_log(outputdir=self.full_outdir)
 
     def save_configs(self, args):
         if not args.config_file:
@@ -192,14 +193,15 @@ class Insight():
 
         self.insight_configfiles = configfiles.InsightConfigFiles(options=args)
         if args.config_sysctl:
-            self.insight_configfiles.save_sysconf(outputdir=self.outdir)
+            self.insight_configfiles.save_sysconf(outputdir=self.full_outdir)
         # collect TiDB configs
         if args.config_auto:
             proc_cmdline = self.format_proc_info("cmd")  # cmdline of process
             self.insight_configfiles.save_configs_auto(
-                proc_cmdline=proc_cmdline, outputdir=self.outdir)
+                proc_cmdline=proc_cmdline, outputdir=self.full_outdir)
         else:
-            self.insight_configfiles.save_tidb_configs(outputdir=self.outdir)
+            self.insight_configfiles.save_tidb_configs(
+                outputdir=self.full_outdir)
 
     def read_pdctl(self, args):
         self.insight_pdctl = pdctl.PDCtl(host=args.pd_host, port=args.pd_port)

--- a/insight.py
+++ b/insight.py
@@ -107,9 +107,19 @@ class Insight():
             perf_proc = self.format_proc_info("name")
             self.insight_perf = perf.InsightPerf(perf_proc, args)
         # parse pid list
-        elif len(args.pid) > 0:
+        elif args.pid:
             perf_proc = {}
             for _pid in args.pid:
+                perf_proc[_pid] = None
+            self.insight_perf = perf.InsightPerf(perf_proc, args)
+        # find process by port
+        elif args.proc_listen_port:
+            perf_proc = {}
+            pid_list = proc_meta.find_process_by_port(
+                args.proc_listen_port, args.proc_port_proto)
+            if not pid_list or len(pid_list) < 1:
+                return
+            for _pid in pid_list:
                 perf_proc[_pid] = None
             self.insight_perf = perf.InsightPerf(perf_proc, args)
         else:

--- a/measurement/files/configfiles.py
+++ b/measurement/files/configfiles.py
@@ -72,8 +72,9 @@ class InsightConfigFiles():
             return file_list
 
         source_dir = self.config_options.config_dir
-        if not os.path.isdir(source_dir):
-            logging.fatal("Source config path is not a directory.")
+        if not source_dir or not os.path.isdir(source_dir):
+            logging.fatal(
+                "Source config path is not a directory. Did you set correct `--config-dir`?")
             return
         output_base = outputdir
         if not output_base:

--- a/measurement/files/logfiles.py
+++ b/measurement/files/logfiles.py
@@ -105,8 +105,9 @@ class InsightLogFiles():
     def save_tidb_logfiles(self, outputdir=None):
         # init values of args
         source_dir = self.log_options.log_dir
-        if not os.path.isdir(source_dir):
-            logging.fatal("Source log path is not a directory.")
+        if not source_dir or not os.path.isdir(source_dir):
+            logging.fatal(
+                "Source log path is not a directory. Did you set correct `--log-dir`?")
             return
         output_base = outputdir
         if not output_base:

--- a/measurement/perf.py
+++ b/measurement/perf.py
@@ -44,17 +44,17 @@ class InsightPerf():
         except (KeyError, TypeError):
             cmd.append("120")  # default to 120Hz
 
-        if pid is not None:
+        if pid:
             cmd.append("-p")
             cmd.append("%d" % pid)
         else:
             cmd.append("-a")  # default to whole system
 
         # default will be perf.data if nothing specified
-        if outfile is not None:
+        if outfile:
             cmd.append("-o")
             cmd.append("%s/%s.data" % (outdir, outfile))
-        elif outfile is None and pid is not None:
+        elif not outfile and pid:
             cmd.append("-o")
             cmd.append("%s/%d.data" % (outdir, pid))
 

--- a/measurement/process/meta.py
+++ b/measurement/process/meta.py
@@ -5,7 +5,9 @@ import os
 from measurement.files import fileutils
 
 
-def find_process_by_port(port=None, protocol="tcp"):
+def find_process_by_port(port=None, protocol=None):
+    if not protocol:
+        protocol = "tcp"
     process_list = []
     if not port:
         logging.fatal("No process listening port specified.")
@@ -24,9 +26,9 @@ def find_process_by_port(port=None, protocol="tcp"):
                             continue
                         _socket = _fd_target.split(":[")[-1][:-1]
                         try:
-                            result[_socket].append(entry.name)
+                            result[_socket].append(int(entry.name))
                         except KeyError:
-                            result[_socket] = [entry.name]
+                            result[_socket] = [int(entry.name)]
                 except PermissionError:
                     logging.warn(
                         "Permission Denied reading /proc/%s/fd" % entry.name)

--- a/measurement/process/meta.py
+++ b/measurement/process/meta.py
@@ -16,22 +16,26 @@ def find_process_by_port(port=None, protocol=None):
     # iterate over all file descriptors and build a socket address -> pid map
     def build_inode_to_pid_map():
         result = {}
-        for entry in os.scandir("/proc"):
+        for entry in fileutils.list_dir("/proc"):
             # find all PIDs
-            if str.isdigit(entry.name):
-                try:
-                    for _fd in os.scandir("/proc/%s/fd" % entry.name):
-                        _fd_target = os.readlink(_fd.path)
-                        if not str.startswith(_fd_target, "socket"):
-                            continue
-                        _socket = _fd_target.split(":[")[-1][:-1]
-                        try:
-                            result[_socket].append(int(entry.name))
-                        except KeyError:
-                            result[_socket] = [int(entry.name)]
-                except PermissionError:
-                    logging.warn(
-                        "Permission Denied reading /proc/%s/fd" % entry.name)
+            fname = entry.split('/')[-1]
+            if str.isdigit(fname):
+                for _fd in fileutils.list_dir("/proc/%s/fd" % fname):
+                    try:
+                        _fd_target = os.readlink(_fd)
+                    except OSError as e:
+                        import errno
+                        if e.errno == errno.ENOENT:
+                            pass
+                        else:
+                            raise e
+                    if not str.startswith(_fd_target, "socket"):
+                        continue
+                    _socket = _fd_target.split(":[")[-1][:-1]
+                    try:
+                        result[_socket].append(int(fname))
+                    except KeyError:
+                        result[_socket] = [int(fname)]
         return result
 
     def find_inode_by_port(port, protocol):

--- a/measurement/process/meta.py
+++ b/measurement/process/meta.py
@@ -27,8 +27,7 @@ def find_process_by_port(port=None, protocol=None):
                         import errno
                         if e.errno == errno.ENOENT:
                             pass
-                        else:
-                            raise e
+                        raise e
                     if not str.startswith(_fd_target, "socket"):
                         continue
                     _socket = _fd_target.split(":[")[-1][:-1]

--- a/measurement/util.py
+++ b/measurement/util.py
@@ -66,6 +66,10 @@ def parse_insight_opts():
                         help="Collect trace info using perf. Disabled by default.")
     parser.add_argument("--pid", type=int, action="append", default=None,
                         help="""PID of process to run perf on. If `-p`/`--perf` is not set, this value will not take effect. Multiple PIDs can be set by using more than one `--pid` argument. `None` by default which means the whole system.""")
+    parser.add_argument("--proc-listen-port", action="store", type=int, default=None,
+                        help="Collect perf data of process that listen on given port. This value will be ignored if `--pid` is set.")
+    parser.add_argument("--proc-port-proto", action="store", default=None,
+                        help="Protocol type of listen port, available values are: tcp/udp. If not set, only TCP listening ports are checked.")
     parser.add_argument("--tidb-proc", action="store_true", default=False,
                         help="Collect perf data for PD/TiDB/TiKV processes instead of the whole system.")
     parser.add_argument("--perf-exec", type=int, action="store", default=None,

--- a/measurement/util.py
+++ b/measurement/util.py
@@ -105,6 +105,8 @@ def parse_insight_opts():
     parser.add_argument("--config-prefix", action="store", default=None,
                         help="The prefix of config files, will be directory name of all config files, will be in the name of output tarball. If `--config-auto` is set, the value will be ignored.")
 
+    parser.add_argument("--pdctl", action="store_true", default=False,
+                        help="Enable collecting data from PD API. Disabled by default.")
     parser.add_argument("--pd-host", action="store", default=None,
                         help="The host of the PD server. `localhost` by default.")
     parser.add_argument("--pd-port", type=int, action="store", default=None,

--- a/measurement/util.py
+++ b/measurement/util.py
@@ -78,6 +78,8 @@ def parse_insight_opts():
                         help="Event sampling frequency of perf-record, in Hz.")
     parser.add_argument("--perf-time", type=int, action="store", default=None,
                         help="Time period of perf recording, in seconds.")
+    parser.add_argument("--perf-archive", action="store_true", default=False,
+                        help="Run `perf archive` after collecting data, useful when reading data on another machine. Disabled by default.")
 
     parser.add_argument("-l", "--log", action="store_true", default=False,
                         help="Collect log files in output. PD/TiDB/TiKV logs are included by default.")

--- a/measurement/util.py
+++ b/measurement/util.py
@@ -68,7 +68,7 @@ def parse_insight_opts():
                         help="""PID of process to run perf on. If `-p`/`--perf` is not set, this value will not take effect. Multiple PIDs can be set by using more than one `--pid` argument. `None` by default which means the whole system.""")
     parser.add_argument("--proc-listen-port", action="store", type=int, default=None,
                         help="Collect perf data of process that listen on given port. This value will be ignored if `--pid` is set.")
-    parser.add_argument("--proc-port-proto", action="store", default=None,
+    parser.add_argument("--proc-listen-proto", action="store", default=None,
                         help="Protocol type of listen port, available values are: tcp/udp. If not set, only TCP listening ports are checked.")
     parser.add_argument("--tidb-proc", action="store_true", default=False,
                         help="Collect perf data for PD/TiDB/TiKV processes instead of the whole system.")


### PR DESCRIPTION
It's now possible to collect perf data of process that listen on specific port.

 + Add ability to collect perf data of process by specifying its listening port
 + Add `--perf-archive` to archive debug info so that the perf data can be read on another machine
 * Fix directory layout of collected log and config files
 - Disable collecting of basic info when calling a specific method (called by ansible)