### PR TITLE
configs: use same directory layout as logfiles

### DIFF
--- a/measurement/files/configfiles.py
+++ b/measurement/files/configfiles.py
@@ -81,14 +81,15 @@ class InsightConfigFiles():
             output_base = source_dir
         file_prefix = self.config_options.config_prefix
 
-        # the full path of output directory
-        output_name = "%s_%s" % (file_prefix, self.config_options.alias)
-        output_dir = os.path.join(output_base, output_name)
-
         # prepare output directory
-        if not fileutils.build_full_output_dir(basedir=output_dir, subdir=self.config_dir):
+        if not fileutils.create_dir(output_base):
             logging.fatal("Failed to prepare output dir.")
             return
+
+        # the full path of output directory
+        output_name = "%s_%s" % (file_prefix, self.config_options.alias)
+        output_dir = fileutils.build_full_output_dir(
+            basedir=os.path.join(output_base, output_name), subdir=self.config_dir)
 
         file_list = list_config_files(source_dir, file_prefix)
         for file in file_list:


### PR DESCRIPTION
Put config files collected to `conf` subdir, just as what we do with log files.