### PR TITLE
pdctl: add port to output files' names

### DIFF
--- a/measurement/tidb/pdctl.py
+++ b/measurement/tidb/pdctl.py
@@ -77,11 +77,11 @@ class PDCtl():
         pd_health = self.read_health()
         if pd_health:
             fileutils.write_file(os.path.join(
-                full_outputdir, "%s-health.json" % self.pd_host), pd_health)
+                full_outputdir, "%s_%s-health.json" % self.pd_host, self.pd_port), pd_health)
         pd_diagnose = self.read_diagnose()
         if pd_diagnose:
             fileutils.write_file(os.path.join(
-                full_outputdir, "%s-diagnose.json" % self.pd_host), pd_diagnose)
+                full_outputdir, "%s_%s-diagnose.json" % self.pd_host, self.pd_port), pd_diagnose)
 
         for key, info in self.read_runtime_info().items():
             if not info:

--- a/measurement/tidb/pdctl.py
+++ b/measurement/tidb/pdctl.py
@@ -87,4 +87,4 @@ class PDCtl():
             if not info:
                 continue
             fileutils.write_file(os.path.join(
-                full_outputdir, "%s-%s.json" % (self.pd_host, key)), info)
+                full_outputdir, "%s_%s-%s.json" % (self.pd_host, self.pd_port, key)), info)


### PR DESCRIPTION
When there're multiple instances of `pd-server` running on same version, the output of querying pd-ctl API are not distinguished, this patch adds port number to the output files' names, to make them unique.