### PR TITLE
logfiles: exclude temp files from recursive copying

### DIFF
--- a/measurement/files/logfiles.py
+++ b/measurement/files/logfiles.py
@@ -130,7 +130,7 @@ class InsightLogFiles():
         file_list = self.get_filelist_in_time(source_dir, file_prefix,
                                               time.time(), retention_hour)
         for file in file_list:
-            if output_name in file:
+            if self.log_options.alias in file:
                 # Skip output files if source and output are the same directory
                 continue
             shutil.copy(file, output_dir)


### PR DESCRIPTION
To avoid running out disk space, `tidb-ansible` set temp file path to log directory, this may results to file conflicting and recursive copying of files.

This commit excludes any file with `alias` in its full path from log file collecting.