### PR TITLE
perf: remove -g flag

### DIFF
--- a/runtime/perf.py
+++ b/runtime/perf.py
@@ -26,7 +26,6 @@ class Perf(MeasurementBase):
     def build_record_cmd(self, pid=None, outfile=None):
         cmd = ["perf",    # default executable name
                "record",  # default action of perf
-               "-g",
                "--call-graph",
                "dwarf"]
 


### PR DESCRIPTION
--call-graph flag implies -g, and -g's default record mode is frame pointers.
man page:
```
-g   enables call-graph recording
--call-graph
           Setup and enable call-graph (stack chain/backtrace) recording, implies -g. Default is "fp".
```
example: http://www.brendangregg.com/perf.html