### PR TITLE
Enable collecting of dmesg and messages

### DIFF
--- a/file/logfiles.py
+++ b/file/logfiles.py
@@ -72,7 +72,7 @@ class InsightLogFiles(FileCollecting):
     def save_system_log(self):
         # save system logs
         if self.options.syslog:
-            if util.get_init_type() == "systemd":
+            if util.get_init_type() == "systemd" and self.options.systemd:
                 logging.info("systemd-journald detected.")
                 self.save_journal_log()
             else:

--- a/file/logfiles.py
+++ b/file/logfiles.py
@@ -111,7 +111,8 @@ class InsightLogFiles(FileCollecting):
     def run_collecting(self, cmdline=None):
         if cmdline:
             self.save_logfiles_auto(cmdline)
+            self.save_system_log()
+        elif self.options.syslog:
+            self.save_system_log()
         else:
             self.save_tidb_logfiles()
-        if self.options.syslog:
-            self.save_system_log()

--- a/file/logfiles.py
+++ b/file/logfiles.py
@@ -77,7 +77,8 @@ class InsightLogFiles(FileCollecting):
                 self.save_journal_log()
             else:
                 logging.info("systemd not detected, assuming syslog.")
-                self.save_syslog()
+            # always save syslogs
+            self.save_syslog()
 
     def save_logfiles_auto(self, proc_cmdline=None):
         # save log files of TiDB modules

--- a/utils/util.py
+++ b/utils/util.py
@@ -150,6 +150,8 @@ def parse_insight_opts():
                             help="The prefix of log files, will be the directory name of all logs, will be in the name of output tarball. If `--log-auto` is set, this value will be ignored.")
     parser_log.add_argument("--retention", type=int, action="store", default=0,
                             help="The time of log retention, any log files older than given time period from current time will not be included. Value should be a number of hour(s) in positive interger. `0` by default and means no time check.")
+    parser_log.add_argument("--systemd", action="store_true", default=False,
+                            help="Collect systemd journald logs, disabled by default.")
 ####
 
 # Sub-command: config


### PR DESCRIPTION
As our recommended OS is CentOS 7;

system logs are stored in `/var/log/dmesg` and `/var/log/messages`, so collect these files unconditionally.