### PR TITLE
tidb: collect /info/all by default, along with /info

### DIFF
--- a/tidb/tidbinfo.py
+++ b/tidb/tidbinfo.py
@@ -17,6 +17,7 @@ class TiDBInfo(MeasurementBase):
     # The API's URI
     uri_map = {
         "info": "/info",
+        "info-all": "/info/all",
         "status": "/status",
         "regions": "/regions/meta",
         "schema": "/schema",


### PR DESCRIPTION
We collect `/info` on every TiDB instances in `inventory.ini`, and in theory their combination is equal with the output of `/info/all`, so this can be used on older versions where `/info/all` is not supported.

And there's possibility that some TiDB instance(s) not defined in `inventory.ini` is/are connected to the cluster (due to wrong manual operations or unfinished change of cluster), so if we have `/info/all` to show every connected instances we can find out if there is such an instance.