### PR TITLE
Read modules versions on process specified by listening port

### DIFF
--- a/explorer/modules.py
+++ b/explorer/modules.py
@@ -69,24 +69,27 @@ class TUIModuleTiDB(TUIModuleBase):
             for proc in self.collector[host]['proc_stats']:
                 if 'tidb' in proc['name']:
                     _proc = proc['memory']
+                else:
+                    continue
 
-            info.append([
-                host,
-                '%s:%s' % (_setting['advertise-address'],
-                           _info['listening_port']),
-                '%s %s' % (_setting['store'], _setting['path']),
-                '%s %s' % (_info['version'], '*' if _info['is_owner'] else '')
-            ])
-            status.append([
-                host,
-                _info['ddl_id'],
-                '%s' % _stat['connections'],
-                '%s' % len(stats['regions']),
-                util.format_size_bytes(_proc['rss']) if _proc else '',
-                util.format_size_bytes(_proc['vms']) if _proc else '',
-                util.format_size_bytes(_proc['swap']) if _proc else '',
-                '*' if _info['is_owner'] else ''
-            ])
+                info.append([
+                    host,
+                    '%s:%s' % (_setting['advertise-address'],
+                               _info['listening_port']),
+                    '%s %s' % (_setting['store'], _setting['path']),
+                    '%s %s' % (_info['version'],
+                               '*' if _info['is_owner'] else '')
+                ])
+                status.append([
+                    host,
+                    _info['ddl_id'],
+                    '%s' % _stat['connections'],
+                    '%s' % len(stats['regions']),
+                    util.format_size_bytes(_proc['rss']) if _proc else '',
+                    util.format_size_bytes(_proc['vms']) if _proc else '',
+                    util.format_size_bytes(_proc['swap']) if _proc else '',
+                    '*' if _info['is_owner'] else ''
+                ])
         result.append(info)
         result.append(status)
 
@@ -115,32 +118,37 @@ class TUIModuleTiKV(TUIModuleBase):
             for proc in self.collector[host]['proc_stats']:
                 if 'tikv' in proc['name']:
                     _proc = proc
-            if not _proc:
-                continue
+                else:
+                    continue
+                if not _proc:
+                    continue
 
-            _cmd = _proc['cmd'].split()
-            try:
-                adv_addr = _cmd[_cmd.index('--advertise-addr') + 1]
-            except ValueError:
-                adv_addr = ''
-            try:
-                pd_addr = _cmd[_cmd.index('--pd') + 1]
-            except ValueError:
-                pd_addr = ''
-            try:
-                rel_ver = '%s-g%s' % (self.collector[host]['meta']['tikv']['release_version'],
-                                      self.collector[host]['meta']['tikv']['git_commit'][:6])
-            except KeyError:
-                rel_ver = ''
-            info.append([
-                host, adv_addr, rel_ver, pd_addr,
-                util.format_size_bytes(
-                    _proc['memory']['rss']) if _proc else '',
-                util.format_size_bytes(
-                    _proc['memory']['vms']) if _proc else '',
-                util.format_size_bytes(
-                    _proc['memory']['swap']) if _proc else ''
-            ])
+                _cmd = _proc['cmd'].split()
+                try:
+                    adv_addr = _cmd[_cmd.index('--advertise-addr') + 1]
+                except ValueError:
+                    adv_addr = ''
+                try:
+                    pd_addr = _cmd[_cmd.index('--pd') + 1]
+                except ValueError:
+                    pd_addr = ''
+                try:
+                    for tikv_vers in self.collector[host]['meta']['tikv']:
+                        if tikv_vers['pid'] != _proc['pid']:
+                            continue
+                        rel_ver = '%s-g%s' % (tikv_vers['release_version'],
+                                              tikv_vers['git_commit'][:6])
+                except KeyError:
+                    rel_ver = ''
+                info.append([
+                    host, adv_addr, rel_ver, pd_addr,
+                    util.format_size_bytes(
+                        _proc['memory']['rss']) if _proc else '',
+                    util.format_size_bytes(
+                        _proc['memory']['vms']) if _proc else '',
+                    util.format_size_bytes(
+                        _proc['memory']['swap']) if _proc else ''
+                ])
         result.append(info)
 
         return result
@@ -203,20 +211,22 @@ class TUIModulePD(TUIModuleBase):
             for proc in self.collector[host]['proc_stats']:
                 if 'pd' in proc['name']:
                     _proc = proc
-            if not _proc:
-                continue
-            _info = self.pdinfo[host]
+                else:
+                    continue
+                if not _proc:
+                    continue
+                _info = self.pdinfo[host]
 
-            header.append([
-                host, _info['config']['name'], _info['config']['cluster-version'],
-                _info['config']['advertise-peer-urls'],
-                util.format_size_bytes(
-                    _proc['memory']['rss']) if _proc else '',
-                util.format_size_bytes(
-                    _proc['memory']['vms']) if _proc else '',
-                util.format_size_bytes(
-                    _proc['memory']['swap']) if _proc else ''
-            ])
+                header.append([
+                    host, _info['config']['name'], _info['config']['cluster-version'],
+                    _info['config']['advertise-peer-urls'],
+                    util.format_size_bytes(
+                        _proc['memory']['rss']) if _proc else '',
+                    util.format_size_bytes(
+                        _proc['memory']['vms']) if _proc else '',
+                    util.format_size_bytes(
+                        _proc['memory']['swap']) if _proc else ''
+                ])
         result.append(header)
 
         cluster_info = []

--- a/explorer/modules.py
+++ b/explorer/modules.py
@@ -62,11 +62,12 @@ class TUIModuleTiDB(TUIModuleBase):
         status.append(['Host', 'DDL-ID', 'Conns', 'Regions',
                        'MemRSS', 'VMS', 'Swap', 'Owner'])
         for host, stats in self.tidbinfo.items():
+            host_alias = 'tidb_%s' % host
             _setting = stats['settings']
             _info = stats['info']
             _stat = stats['status']
             _proc = None
-            for proc in self.collector[host]['proc_stats']:
+            for proc in self.collector[host_alias]['proc_stats']:
                 if 'tidb' in proc['name']:
                     _proc = proc['memory']
                 else:
@@ -114,8 +115,9 @@ class TUIModuleTiKV(TUIModuleBase):
                      'PD', 'MemRSS', 'VMS', 'Swap'])
         for host in self.hosts:
             host = str(host)
+            host_alias = 'tikv_%s' % host
             _proc = None
-            for proc in self.collector[host]['proc_stats']:
+            for proc in self.collector[host_alias]['proc_stats']:
                 if 'tikv' in proc['name']:
                     _proc = proc
                 else:
@@ -133,7 +135,7 @@ class TUIModuleTiKV(TUIModuleBase):
                 except ValueError:
                     pd_addr = ''
                 try:
-                    for tikv_vers in self.collector[host]['meta']['tikv']:
+                    for tikv_vers in self.collector[host_alias]['meta']['tikv']:
                         if tikv_vers['pid'] != _proc['pid']:
                             continue
                         rel_ver = '%s-g%s' % (tikv_vers['release_version'],
@@ -207,8 +209,9 @@ class TUIModulePD(TUIModuleBase):
                        'URL', 'MemRSS', 'VMS', 'Swap'])
         for host in self.hosts:
             host = str(host)
+            host_alias = 'pd_%s' % host
             _proc = None
-            for proc in self.collector[host]['proc_stats']:
+            for proc in self.collector[host_alias]['proc_stats']:
                 if 'pd' in proc['name']:
                     _proc = proc
                 else:

--- a/explorer/summary.py
+++ b/explorer/summary.py
@@ -59,9 +59,10 @@ class TUISummary(tui.TUIBase):
         for tikv_host in self.tikv.hosts:
             tikv_host = str(tikv_host)
             try:
-                rel_ver = '%s-g%s' % (self.tikv.collector[tikv_host]['meta']['tikv']['release_version'],
-                                      self.tikv.collector[tikv_host]['meta']['tikv']['git_commit'][:6])
-                tikv_versions.append(rel_ver)
+                for instance in self.tikv.collector[tikv_host]['meta']['tikv']:
+                    rel_ver = '%s-g%s' % (instance['release_version'],
+                                          instance['git_commit'][:6])
+                    tikv_versions.append(rel_ver)
             except KeyError:
                 continue
         sum_tikv = ['TiKV', '%s' % len(self.tikv.hosts),


### PR DESCRIPTION
When reading information of a process of TiDB/TiKV/PD instance, the versions also are read only for that (those) process(es), instead of auto-detect running process, which may be inaccurate on multi-instance hosts.

This fixes #46 