### PR TITLE
workaround unexpected  behavior tikv-server -V

### DIFF
--- a/collector/tikv.go
+++ b/collector/tikv.go
@@ -29,7 +29,7 @@ func getTiKVVersion(proc *process.Process) TiKVMeta {
 		log.Fatal(err)
 	}
 
-	cmd := exec.Command(file, "-V")
+	cmd := exec.Command(file, "--version")
 	var out bytes.Buffer
 	cmd.Stdout = &out
 	err = cmd.Run()


### PR DESCRIPTION
In v2.x.x `tikv-server -V` print out:
```
TiKV
Release Version: 2.1.14
Git Commit Hash: 32ca82bc067f7529dc07bf8ddb594b8c060b7f49
Git Commit Branch: HEAD
UTC Build Time: 2019-07-04 10:32:40
Rust Version: rustc 1.29.0-nightly (4f3c7a472 2018-07-17)
```
However, in v3.x and later version, it just print out:
```TiKV x.x.x```
This cause that collector does not parse tikv version correctly.

Signed-off-by: lucklove <gnu.crazier@gmail.com>