### PR TITLE
Makefile: add support to build for other arch than amd64

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -1,6 +1,10 @@
 ### Makefile for tidb-insight
 .PHONY: collector tools
 
+GOOS    := $(if $(GOOS),$(GOOS),linux)
+GOARCH  := $(if $(GOARCH),$(GOARCH),amd64)
+HOSTARCH:= $(if $(HOSTARCH),$(HOSTARCH),amd64)
+
 default: collector tools
 
 debug: collector tools
@@ -8,15 +12,15 @@ debug: collector tools
 all: default
 
 collector:
-	$(MAKE) -C collector $(MAKECMDGOALS)
+	GOOS=$(GOOS) GOARCH=$(GOARCH) HOSTARCH=$(HOSTARCH) $(MAKE) -C collector $(MAKECMDGOALS)
 
 tools:
-	$(MAKE) -C tools $(MAKECMDGOALS)
+	GOOS=$(GOOS) GOARCH=$(GOARCH) HOSTARCH=$(HOSTARCH) $(MAKE) -C tools $(MAKECMDGOALS)
 	$(MAKE) -C tools/vmtouch $(MAKECMDGOALS)
 	install -Dm755 tools/vmtouch/vmtouch bin/
 
 package:
-	./package.sh
+	GOOS=$(GOOS) GOARCH=$(GOARCH) HOSTARCH=$(HOSTARCH) ./package.sh
 
 clean:
 	rm -rf bin

--- a/collector/Makefile
+++ b/collector/Makefile
@@ -10,6 +10,8 @@ ifeq "$(GOBIN)" ""
 else
     GO    := GOPATH=$(GOPATH) $(GOBIN)
 endif
+GOOS    := $(if $(GOOS),$(GOOS),linux)
+GOARCH  := $(if $(GOARCH),$(GOARCH),amd64)
 GOBUILD   := $(GO) build
 
 COMMIT    := $(shell git rev-parse HEAD)
@@ -35,7 +37,7 @@ release:
 		-i *.go
 
 static:
-	CGO_ENABLED=0 GOOS=linux GOARCH=amd64 \
+	CGO_ENABLED=0 GOOS=$(GOOS) GOARCH=$(GOARCH) \
 	$(GOBUILD) -ldflags '-s -w -extldflags "-static" $(LDFLAGS)' \
 		-o ../bin/collector \
 		-i *.go

--- a/package.sh
+++ b/package.sh
@@ -11,7 +11,7 @@ else
 fi
 RELPATH=${PKGNAME}-${RELVER}
 
-GO_RELEASE_BIN=go1.11.linux-amd64
+GO_RELEASE_BIN=go1.11.13.linux-${HOSTARCH}
 
 BUILD_ROOT="`pwd`/.build"
 mkdir -p ${BUILD_ROOT}
@@ -37,9 +37,9 @@ ln -sfv vendor src
 
 # compile a static binary
 cd ${BUILD_ROOT}/${PKGNAME}/collector/
-GOBIN=${GOROOT}/bin/go make static || exit 1
+GOBIN=${GOROOT}/bin/go GOOS=${GOOS} GOARCH=${GOARCH} make static || exit 1
 cd ${BUILD_ROOT}/${PKGNAME}/tools/
-GOBIN=${GOROOT}/bin/go make static || exit 1
+GOBIN=${GOROOT}/bin/go GOOS=${GOOS} GOARCH=${GOARCH} make static || exit 1
 
 # compile other tools
 cd ${BUILD_ROOT}/${PKGNAME}/tools/vmtouch

--- a/tools/Makefile
+++ b/tools/Makefile
@@ -10,6 +10,8 @@ ifeq "$(GOBIN)" ""
 else
     GO    := GOPATH=$(GOPATH) $(GOBIN)
 endif
+GOOS    := $(if $(GOOS),$(GOOS),linux)
+GOARCH  := $(if $(GOARCH),$(GOARCH),amd64)
 GOBUILD   := $(GO) build
 
 default: release
@@ -27,7 +29,7 @@ release:
 		-i prom2influx.go
 
 static:
-	CGO_ENABLED=0 GOOS=linux GOARCH=amd64 \
+	CGO_ENABLED=0 GOOS=$(GOOS) GOARCH=$(GOARCH) \
 	$(GOBUILD) -ldflags '-s -w -extldflags "-static" $(LDFLAGS)' \
 		-o ../bin/prom2influx \
 		-i prom2influx.go


### PR DESCRIPTION
Add basic support of building on system with arch other than `amd64`, e.g., for `arm64`.

It's not fully supported to cross compile for another arch, build it on the target arch is a must (for now).