### PR TITLE
release: add new version which build in darwin os

### DIFF
--- a/.github/workflows/release.yaml
+++ b/.github/workflows/release.yaml
@@ -23,6 +23,7 @@ jobs:
       matrix:
         os:
           - "linux"
+          - "darwin"
         arch:
           - "amd64"
           - "arm64"


### PR DESCRIPTION
add new version which build in darwin os
```
matrix:
        os:
          - "linux"
          - "darwin"
        arch:
          - "amd64"
          - "arm64"
```