### PR TITLE
Revert "release: add new version which build in darwin os"

### DIFF
--- a/.github/workflows/release.yaml
+++ b/.github/workflows/release.yaml
@@ -23,7 +23,6 @@ jobs:
       matrix:
         os:
           - "linux"
-          - "darwin"
         arch:
           - "amd64"
           - "arm64"


### PR DESCRIPTION
Reverts pingcap/tidb-insight#59

Not building on darwin-arm64 yet.