### PR TITLE
collector: improve portability

### DIFF
--- a/collector/insight/process.go
+++ b/collector/insight/process.go
@@ -2,7 +2,6 @@
 package insight
 
 import (
-	"io/ioutil"
 	"log"
 	"strconv"
 	"strings"
@@ -154,20 +153,6 @@ func getRlimitUsage(proc *process.Process) []RlimitUsage {
 		result = append(result, usage)
 	}
 	return result
-}
-
-func getProcStartTime(proc *process.Process) (float64, error) {
-	statPath := GetProcPath(strconv.Itoa(int(proc.Pid)), "stat")
-	contents, err := ioutil.ReadFile(statPath)
-	if err != nil {
-		log.Fatal(err)
-		return 0, err
-	}
-	fields := strings.Fields(string(contents))
-	if startTime, err := strconv.ParseFloat(fields[21], 64); err == nil {
-		return startTime / float64(process.ClockTicks), err
-	}
-	return 0, err
 }
 
 func (proc_stat *ProcessStat) getProcessStat(proc *process.Process) {

--- a/collector/insight/process_linux.go
+++ b/collector/insight/process_linux.go
@@ -1,0 +1,23 @@
+//go:build linux
+// +build linux
+
+package insight
+
+import (
+	"github.com/shirou/gopsutil/process"
+	"io/ioutil"
+)
+
+func getProcStartTime(proc *process.Process) (float64, error) {
+	statPath := GetProcPath(strconv.Itoa(int(proc.Pid)), "stat")
+	contents, err := ioutil.ReadFile(statPath)
+	if err != nil {
+		log.Fatal(err)
+		return 0, err
+	}
+	fields := strings.Fields(string(contents))
+	if startTime, err := strconv.ParseFloat(fields[21], 64); err == nil {
+		return startTime / float64(process.ClockTicks), err
+	}
+	return 0, err
+}

--- a/collector/insight/process_linux.go
+++ b/collector/insight/process_linux.go
@@ -4,8 +4,12 @@
 package insight
 
 import (
-	"github.com/shirou/gopsutil/process"
 	"io/ioutil"
+	"log"
+	"strconv"
+	"strings"
+
+	"github.com/shirou/gopsutil/process"
 )
 
 func getProcStartTime(proc *process.Process) (float64, error) {

--- a/collector/insight/process_others.go
+++ b/collector/insight/process_others.go
@@ -1,0 +1,12 @@
+//go:build !linux
+// +build !linux
+
+package insight
+
+import (
+	"github.com/shirou/gopsutil/process"
+)
+
+func getProcStartTime(proc *process.Process) (float64, error) {
+	return 0, nil
+}


### PR DESCRIPTION
Closes #62 

`getProcStartTime()` reads `/proc/<pid>/stat` to get the startime of the process and then divides this by `process.ClockTicks`, which basically is `sysconf.SC_CLK_TCK` which in most if not all cases is 100.

The problem with this is that this uses `process.ClockTicks` which wasn't meant to be exposed. The other problem with this is that this is very Linux specific.

Using gopsutil's [CreateTime()](https://pkg.go.dev/github.com/shirou/gopsutil@v3.21.10+incompatible/process#Process.CreateTime) would be a better solution, but that returns the time since the UNIX epoch and not the time since the last boot as `getProcStartTime()` does.

See also [proc(5)](https://man7.org/linux/man-pages/man5/proc.5.html) for what this field of `/proc/<pid>/stat` represents:
```
              (22) starttime  %llu
                     The time the process started after system boot.  In
                     kernels before Linux 2.6, this value was expressed
                     in jiffies.  Since Linux 2.6, the value is
                     expressed in clock ticks (divide by
                     sysconf(_SC_CLK_TCK)).

                     The format for this field was %lu before Linux 2.6.
```

I don't see this being used in https://github.com/pingcap/diag or https://github.com/pingcap/tiup cluster so keeping the same behaviour on Linux and letting this compile on other platforms by always returning 0 seems a reasonable solution to me.